### PR TITLE
follow debian

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,1 +1,1 @@
-git_src_commit 030187f27674c39da51658a0505135b15d7693e2 https://salsa.debian.org/selinux-team/libsemanage.git
+apt_src libsemanage


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to use the normal libsemanage package provided by Debian instead of the previously used git commit.
This was just a workaround to fix the missing package.

